### PR TITLE
Allow client configuration to be dynamic

### DIFF
--- a/src/DI/GuzzleExtension.php
+++ b/src/DI/GuzzleExtension.php
@@ -21,7 +21,7 @@ class GuzzleExtension extends CompilerExtension
 	{
 		return Expect::structure([
 			'debug' => Expect::bool(false),
-			'client' => Expect::array()->default([
+			'client' => Expect::array()->dynamic()->default([
 				'timeout' => 30,
 			]),
 		]);

--- a/tests/Cases/GuzzleExtensionTest.phpt
+++ b/tests/Cases/GuzzleExtensionTest.phpt
@@ -57,6 +57,28 @@ class GuzzleExtensionTest extends TestCase
 		Assert::count(1, $container->findByType(ClientFactory::class));
 	}
 
+	public function testExtensionDynamic(): void
+	{
+		$loader = new ContainerLoader(TEMP_DIR, true);
+		$class = $loader->load(function (Compiler $compiler): void {
+			$compiler->setDynamicParameterNames(['guzzle-client']);
+			$compiler->addConfig([
+				'parameters'=>[
+				    'guzzle-client' => [],
+				],
+				'guzzle' => [
+					'client' => '%guzzle-client%'
+				],
+			]);
+			$compiler->addExtension('guzzle', new GuzzleExtension());
+		}, [getmypid(), 1]);
+
+		/** @var Container $container */
+		$container = new $class();
+
+		Assert::count(1, $container->findByType(Client::class));
+		Assert::count(1, $container->findByType(ClientFactory::class));
+	}
 }
 
 (new GuzzleExtensionTest())->run();


### PR DESCRIPTION
It solves compatibility issue with nette/di 3.1.4:
```
Nette\DI\InvalidConfigurationException

The item 'contributte.guzzle › client' expects to be array, object Nette\DI\DynamicParameter given.
```

My config looks like this:
```neon
parameters:
	guzzleClientConfig:
		timeout: 30
		verify: Composer\CaBundle\CaBundle::getSystemCaRootBundlePath()

contributte.guzzle:
	debug: %debugMode%
	client: %guzzleClientConfig%
```

The issue is, that `guzzleClientConfig.verify` is PHP code. nette/di:3.1.4 starts to deal with it in a new way, which breaks things.