### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Remove `phpdbg` from the `coverage` target and run coverage through `php` instead.

## Motivation

This repository is part of the org-wide migration tracked in contributte/contributte#73.

## Changes

- replace `-p phpdbg` with `-p php` in both `coverage` target variants in `Makefile`
- keep the existing coverage output paths unchanged

## Testing

- [x] `make tests`
- [ ] `make coverage` locally (`Xdebug or PCOV extension or PHPDBG SAPI` is not available in this environment)
- [ ] CI passes