### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,5 +15,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.2"


### PR DESCRIPTION
## What changed
- add \'secrets: inherit\' to the reusable coverage workflow caller in `.github/workflows/coverage.yml`

## Why
- allow the coverage workflow to receive the required inherited secrets during CI rollout for contributte/contributte#74